### PR TITLE
Fixed Package Version During deployment. 

### DIFF
--- a/src/pages/DemoAccountFlowPage.page-meta.xml
+++ b/src/pages/DemoAccountFlowPage.page-meta.xml
@@ -4,14 +4,4 @@
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>DemoAccountFlowPage</label>
-    <packageVersions>
-        <majorNumber>2</majorNumber>
-        <minorNumber>8</minorNumber>
-        <namespace>dlrs</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
-        <minorNumber>7</minorNumber>
-        <namespace>sf_com_apps</namespace>
-    </packageVersions>
 </ApexPage>

--- a/src/pages/DemoAccountFlowPage.page-meta.xml
+++ b/src/pages/DemoAccountFlowPage.page-meta.xml
@@ -11,11 +11,6 @@
     </packageVersions>
     <packageVersions>
         <majorNumber>1</majorNumber>
-        <minorNumber>13</minorNumber>
-        <namespace>sf_chttr_apps</namespace>
-    </packageVersions>
-    <packageVersions>
-        <majorNumber>1</majorNumber>
         <minorNumber>7</minorNumber>
         <namespace>sf_com_apps</namespace>
     </packageVersions>


### PR DESCRIPTION
As Deployment is failing removed package version for below app.

The specified Package Version number does not exist for that Package: sf_chttr_apps, 1.13